### PR TITLE
Check APT Package Versions

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -31,7 +31,7 @@ for package in $packages; do
 
   echo -n "  Caching to $cache_filepath..."
   # Pipe all package files (no folders) to Tar.
-  dpkg -L $package |
+  dpkg -L "$(echo "${package}" | cut -d"=" -f1)" |
     while IFS= read -r f; do     
       if test -f $f; then echo ${f:1}; fi;  #${f:1} removes the leading slash that Tar disallows
     done | 
@@ -44,6 +44,7 @@ manifest_filepath="$cache_dir/manifest.log"
 echo -n "Writing package manifest to $manifest_filepath..."
 manifest=
 for package in $packages; do
+  package="$(echo "${package}" | cut -d"=" -f1)"
   manifest=$manifest$package:$(dpkg -s $package | grep Version | awk '{print $2}'),
 done  
 # Remove trailing comma.

--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -1,40 +1,56 @@
 #!/bin/bash
 
 # Directory that holds the cached packages.
-cache_dir=$1
+cache_dir="${1}"
 
 # Version of the cache to create or load.
-version=$2
+version="${2}"
 
 # List of the packages to use.
-packages=${@:3}
+packages="${@:3}"
+
+# Sort these packages by name and split on commas.
+packages=$(echo "${packages}" | sed 's/[\s,]+/ /g' | tr ' ' '\n' | sort | tr '\n' ' ')
 
 # Create cache directory so artifacts can be saved.
-mkdir -p $cache_dir
+mkdir -p "${cache_dir}"
 
-echo -n "Validating action arguments (version='$version', packages='$packages')...";
-echo $version | grep -o " " > /dev/null
-if [ $? -eq 0 ]; then
+echo -n "Validating action arguments (version='${version}', packages='${packages}')...";
+
+if echo "${version}" | grep -q " " > /dev/null; then
   echo "aborted." 
-  echo "Version value '$version' cannot contain spaces." >&2
+  echo "Version value '${version}' cannot contain spaces." >&2
   exit 1
 fi
-if [ "$packages" == "" ]; then
+if [ "${packages}" == "" ]; then
   echo "aborted." 
   echo "Packages argument cannot be empty." >&2
   exit 2
 fi
 echo "done."
 
+echo -n "Updating APT package list..."
+sudo apt-get update > /dev/null
+echo "done."
+
 echo -n "Verifying packages..."
-for package in $packages; do
-  escaped=$(echo $package | sed 's/+/\\+/g')
-  apt-cache search ^$escaped$ | grep $package > /dev/null
-  if [ $? -ne 0 ]; then
+for package in ${packages}; do
+  if echo "${package}" | grep -q "="; then
+    pkg_name=$(echo "${package}" | cut -d "=" -f1)
+    pkg_ver=$(echo "${package}" | cut -d "=" -f2)
+  else
+    pkg_name="${package}"
+  fi
+  apt_show=$(apt show "${package}")
+  if echo ${apt_show} | grep -qi "No packages found" > /dev/null; then
     echo "aborted."
-    echo "Package '$package' not found." >&2
+    echo "Package '${package}' not found." >&2
     exit 3
   fi
+  if [ -z "${pkg_ver}" ]; then
+    pkg_ver=$(echo "${apt_show}" | grep -Po "(?<=Version: )[^\s]+")
+  fi
+  package_list="${package_list} ${pkg_name}=${pkg_ver}"
 done
 echo "done."
 
@@ -43,18 +59,18 @@ set -e
 
 echo "Creating cache key..."
 
-# Remove package delimiters, sort (requires newline) and then convert back to inline list.
-normalized_list=$(echo $packages | sed 's/[\s,]+/ /g' | tr ' ' '\n' | sort | tr '\n' ' ')
-echo "- Normalized package list is '$normalized_list'."
+# Remove extraneous spaces
+package_list="$(echo "${package_list}" | sed 's/\s\+/ /g;s/^\s\+//g;s/\s\+$//g')"
+echo "- Normalized package list is '$package_list'."
 
-value=$(echo $normalized_list @ $version)
-echo "- Value to hash is '$value'."
+value=$(echo "${package_list} @ ${version}")
+echo "- Value to hash is '${value}'."
 
-key=$(echo $value | md5sum | /bin/cut -f1 -d' ')
+key=$(echo "${value}" | md5sum | /bin/cut -f1 -d' ')
 echo "- Value hashed as '$key'."
 
 echo "done."
 
-key_filepath="$cache_dir/cache_key.md5"
-echo $key > $key_filepath
-echo "Hash value written to $key_filepath"
+key_filepath="${cache_dir}/cache_key.md5"
+echo "${key}" > "${key_filepath}"
+echo "Hash value written to ${key_filepath}"


### PR DESCRIPTION
Make sure to keep the cache up to date as package versions change
upstream. Also, allow specific package versions to be selected.