### PR TITLE
Remove compression from file caching.

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -75,7 +75,7 @@ for installed_package in ${installed_packages}; do
       while IFS= read -r f; do     
         if test -f $f || test -L $f; then echo "${f:1}"; fi;  #${f:1} removes the leading slash that Tar disallows
       done |
-      xargs tar -czf "${cache_filepath}" -C /      
+      sudo xargs tar -czf "${cache_filepath}" -C /      
     log "    done (compressed size $(du -h "${cache_filepath}" | cut -f1))."
   fi
 

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -64,7 +64,7 @@ log_empty_line
 installed_package_count=$(wc -w <<< "${installed_packages}")
 log "Caching ${installed_package_count} installed packages..."
 for installed_package in ${installed_packages}; do
-  cache_filepath="${cache_dir}/${installed_package}.tar.gz"
+  cache_filepath="${cache_dir}/${installed_package}.tar"
 
   # Sanity test in case APT enumerates duplicates.
   if test ! -f "${cache_filepath}"; then
@@ -75,7 +75,7 @@ for installed_package in ${installed_packages}; do
       while IFS= read -r f; do     
         if test -f $f || test -L $f; then echo "${f:1}"; fi;  #${f:1} removes the leading slash that Tar disallows
       done |
-      sudo xargs tar -czf "${cache_filepath}" -C /      
+      sudo xargs tar -cf "${cache_filepath}" -C /      
     log "    done (compressed size $(du -h "${cache_filepath}" | cut -f1))."
   fi
 

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -31,7 +31,7 @@ log "done"
 log_empty_line
 
 # Only search for archived results. Manifest and cache key also live here.
-cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar.gz | sort)
+cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar | sort)
 cached_pkg_filecount=$(echo ${cached_pkg_filepaths} | wc -w)
 log "Restoring ${cached_pkg_filecount} packages from cache..."
 for cached_pkg_filepath in ${cached_pkg_filepaths}; do


### PR DESCRIPTION
The [actions/cache](https://github.com/actions/cache) already compresses the cache that it restores. Any additional compression (i.e. cached packages) is redundant and incurs more overhead by having to compress even set of files. Decided to remove this entirely so the whole action can be sped up.