### PR TITLE
Execute installation scripts and debug mode features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 
 * `packages` - Space delimited list of packages to install.
 * `version` - Version of cache to load. Each version will have its own cache. Note, all characters except spaces are allowed.
+* `execute_install_scripts` - Execute Debian package pre and post install script upon restore. See [Caveats / Non-file Dependencies](#non-file-dependencies) for more information.
 
 ### Outputs
 
@@ -74,6 +75,34 @@ jobs:
           version: 1.0
 ```
 
-## Cache Limits
+## Caveats
+
+### Non-file Dependencies
+
+This action is based on the principle that most packages can be cached as a fileset. There are situations though where this is not enough.
+
+* Pre and post installation scripts needs to be ran from `/var/lib/dpkg/info/{package name}.[preinst, postinst]`.
+* The Debian package database needs to be queried for scripts above (i.e. `dpkg-query`).
+
+The `execute_install_scripts` argument can be used to attempt to execute the install scripts but they are no guaranteed to resolve the issue.
+
+```yaml
+- uses: awalsh128/cache-apt-pkgs-action@latest
+  with:
+    packages: mypackage
+    version: 1.0
+    execute_install_scripts: true
+```
+
+If this does not solve your issue, you will need to run `apt-get install` as a separate step for that particular package unfortunately.
+
+```yaml
+run: apt-get install mypackage
+shell: bash
+```
+
+Please reach out if you have found a workaround for your scenario and it can be generalized. There is only so much this action can do and can't get into the area of reverse engineering Debian package manager. It would be beyond the scope of this action and may result in a lot of extended support and brittleness. Also, it would be better to contribute to Debian packager instead at that point.
+
+### Cache Limits
 
 A repository can have up to 5GB of caches. Once the 5GB limit is reached, older caches will be evicted based on when the cache was last accessed.  Caches that are not accessed within the last week will also be evicted.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ This action is a composition of [actions/cache](https://github.com/actions/cache
 
 Create a workflow `.yml` file in your repositories `.github/workflows` directory. An [example workflow](#example-workflow) is available below. For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
+### Versions
+
+There are three kinds of version labels you can use.
+
+* `@latest` - This will give you the latest release.
+* `@v#` - Major only will give you the latest release for that major version only (e.g. `v1`).
+* Branch
+  * `@master` - Most recent manual and automated tested code. Possibly unstable since it is pre-release.
+  * `@staging` - Most recent automated tested code and can sometimes contain experimental features. Is pulled from dev stable code.
+  * `@dev` - Very unstable and contains experimental features. Automated testing may not show breaks since CI is also updated based on code in dev.
+
 ### Inputs
 
 * `packages` - Space delimited list of packages to install.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     name: Build Doxygen documentation and deploy
     steps:
       - uses: actions/checkout@v2
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: dia doxygen doxygen-doc doxygen-gui doxygen-latex graphviz mscgen
           version: 1.0
@@ -68,11 +68,10 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v2
-      - uses: awalsh128/cache-apt-pkgs-action@v1
+      - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: dia doxygen doxygen-doc doxygen-gui doxygen-latex graphviz mscgen
           version: 1.0
-          refresh: true # Force refresh / upgrade v1.0 cache.
 ```
 
 ## Cache Limits

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ shell: bash
 
 Please reach out if you have found a workaround for your scenario and it can be generalized. There is only so much this action can do and can't get into the area of reverse engineering Debian package manager. It would be beyond the scope of this action and may result in a lot of extended support and brittleness. Also, it would be better to contribute to Debian packager instead at that point.
 
+For more context and information see [issue #57](https://github.com/awalsh128/cache-apt-pkgs-action/issues/57#issuecomment-1321024283) which contains the investigation and conclusion.
+
 ### Cache Limits
 
 A repository can have up to 5GB of caches. Once the 5GB limit is reached, older caches will be evicted based on when the cache was last accessed.  Caches that are not accessed within the last week will also be evicted.

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,11 @@ inputs:
   version:
     description: 'Version will create a new cache and install packages.'
     required: false
-    default: ''  
+    default: '' 
+  execute_postinst:
+    description: 'Execute Debian package postinst script upon restore. Required by some packages.'
+    required: false
+    default: 'false'
   refresh:
     description: 'Option to refresh / upgrade the packages in the same cache.'
     required: false
@@ -56,6 +60,7 @@ runs:
           ~/cache-apt-pkgs \
           / \
           "${{ steps.load-cache.outputs.cache-hit }}" \
+          "${{ inputs.execute_postinst }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
         echo "::set-output name=package-version-list::$(create_list main)"

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
           "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
-        echo "::set-output name=package-version-list::$(create_list main)"
-        echo "::set-output name=all-package-version-list::$(create_list all)"
+        echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
+        echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: upload-logs

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
           "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
-        echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
-        echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
+        echo "::set-output name=package-version-list::$(create_list main)"
+        echo "::set-output name=all-package-version-list::$(create_list all)"
       shell: bash
 
     - id: upload-logs

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,10 @@ inputs:
     default: 'false'
   refresh:
     description: 'OBSOLETE, use version instead.'
-
+  debug:
+    description: 'Debug issues with action. Minor performance penalty.'
+    required: false
+    default: 'false'
 
 outputs:
   cache-hit:
@@ -68,6 +71,7 @@ runs:
       shell: bash
 
     - id: upload-logs
+      if: ${{ inputs.debug }} == "true"
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.packages }}%${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -66,3 +66,10 @@ runs:
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
         echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash
+
+    - id: upload-logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: action-logs
+        path: |
+          ~/cache-apt-pkgs/*.log

--- a/action.yml
+++ b/action.yml
@@ -11,17 +11,16 @@ inputs:
     required: true
     default: ''
   version:
-    description: 'Version will create a new cache and install packages.'
+    description: 'Version of cache to load. Each version will have its own cache. Note, all characters except spaces are allowed.'
     required: false
     default: '' 
-  execute_postinst:
-    description: 'Execute Debian package postinst script upon restore. Required by some packages.'
+  execute_install_scripts:
+    description: 'Execute Debian package pre and post install script upon restore. See README.md caveats for more information.'
     required: false
     default: 'false'
   refresh:
-    description: 'Option to refresh / upgrade the packages in the same cache.'
-    required: false
-    default: 'false'
+    description: 'OBSOLETE, use version instead.'
+
 
 outputs:
   cache-hit:
@@ -44,6 +43,7 @@ runs:
         ${{ github.action_path }}/pre_cache_action.sh \
           ~/cache-apt-pkgs \
           "${{ inputs.version }}" \
+          "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
       shell: bash
@@ -60,6 +60,7 @@ runs:
           ~/cache-apt-pkgs \
           / \
           "${{ steps.load-cache.outputs.cache-hit }}" \
+          "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,6 @@ runs:
           "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
-        echo "name=package-version-list1::$(create_list main)"
-        echo "name=package-version-list2::$(create_list all)"
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
         echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ runs:
         ${{ github.action_path }}/pre_cache_action.sh \
           ~/cache-apt-pkgs \
           "${{ inputs.version }}" \
+          "${{ inputs.execute_postinst }}" \
           ${{ inputs.packages }}
         echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
       shell: bash
@@ -63,6 +64,6 @@ runs:
           "${{ inputs.execute_postinst }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
-        echo "::set-output name=package-version-list::$(create_list main)"
-        echo "::set-output name=all-package-version-list::$(create_list all)"
+        echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
+        echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,6 @@ runs:
         ${{ github.action_path }}/pre_cache_action.sh \
           ~/cache-apt-pkgs \
           "${{ inputs.version }}" \
-          "${{ inputs.execute_postinst }}" \
           ${{ inputs.packages }}
         echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
       shell: bash
@@ -61,7 +60,6 @@ runs:
           ~/cache-apt-pkgs \
           / \
           "${{ steps.load-cache.outputs.cache-hit }}" \
-          "${{ inputs.execute_postinst }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,5 @@ runs:
     - id: upload-logs
       uses: actions/upload-artifact@v3
       with:
-        name: action-logs
-        path: |
-          ~/cache-apt-pkgs/*.log
+        name: ${{ inputs.packages }}%${{ inputs.version }}
+        path: ~/cache-apt-pkgs/*.log

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ runs:
           "${{ inputs.execute_install_scripts }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
+        echo "name=package-version-list1::$(create_list main)"
+        echo "name=package-version-list2::$(create_list all)"
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
         echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
           ~/cache-apt-pkgs \
           "${{ inputs.version }}" \
           "${{ inputs.execute_install_scripts }}" \
+          "${{ inputs.debug }}" \
           ${{ inputs.packages }}
         echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
       shell: bash
@@ -64,6 +65,7 @@ runs:
           / \
           "${{ steps.load-cache.outputs.cache-hit }}" \
           "${{ inputs.execute_install_scripts }}" \
+          "${{ inputs.debug }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
         echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
@@ -74,5 +76,5 @@ runs:
       if: ${{ inputs.debug }} == "true"
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.packages }}%${{ inputs.version }}
+        name: cache-apt-pkgs-logs%${{ inputs.packages }}%${{ inputs.version }}
         path: ~/cache-apt-pkgs/*.log

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   refresh:
     description: 'OBSOLETE, use version instead.'
   debug:
-    description: 'Debug issues with action. Minor performance penalty.'
+    description: 'Enable debugging when there are issues with action. Minor performance penalty.'
     required: false
     default: 'false'
 

--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,8 @@ runs:
           "${{ inputs.debug }}" \
           ${{ inputs.packages }}
         function create_list { local list=$(cat ~/cache-apt-pkgs/manifest_${1}.log | tr '\n' ','); echo ${list:0:-1}; };
-        echo "name=package-version-list::$(create_list main)" >> $GITHUB_OUTPUT
-        echo "name=all-package-version-list::$(create_list all)" >> $GITHUB_OUTPUT
+        echo "package-version-list=$(create_list main)" >> $GITHUB_OUTPUT
+        echo "all-package-version-list=$(create_list all)" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: upload-logs

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -75,7 +75,7 @@ for installed_package in ${installed_packages}; do
       while IFS= read -r f; do     
         if test -f $f || test -L $f; then echo "${f:1}"; fi;  #${f:1} removes the leading slash that Tar disallows
       done |
-      xargs tar -czf "${cache_filepath}" -C /      
+      sudo xargs tar -czf "${cache_filepath}" -C /      
     log "    done (compressed size $(du -h "${cache_filepath}" | cut -f1))."
   fi
 

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -64,10 +64,8 @@ done
 
 log_empty_line
 
-# Post install script install location.
-postinst_filepath="/tmp/deb-ctrl-data/postinst"
-postinst_dirpath=$(dirname ${postinst_filepath})
-mkdir "${postinst_dirpath}"
+# Post install script install location {package name}.postinst
+postinst_dirpath="/var/lib/dpkg/info/"
 
 installed_package_count=$(wc -w <<< "${installed_packages}")
 log "Caching ${installed_package_count} installed packages..."
@@ -87,12 +85,9 @@ for installed_package in ${installed_packages}; do
       sudo xargs tar -cf "${cache_filepath}" -C /
 
     # Append post install scripts if enabled and available.
-    if test "${execute_postinst}" == "true"; then
-      dpkg -e pkg "${postinst_dirpath}"
-      if test -f "${postinst_filepath}"; then
-        tar -caf "${cache_filepath}" "${postinst_filepath}"
-        rm "${postinst_filepath}"
-      fi
+    postinst_filepath=$(get_postinst_filepath "${package_name}")
+    if test "${execute_postinst}" == "true" && test ! -z "${postinst_filepath}"; then
+      tar -caf "${cache_filepath}" "${postinst_filepath}"
     fi
 
     log "    done (compressed size $(du -h "${cache_filepath}" | cut -f1))."

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -67,7 +67,7 @@ log_empty_line
 # Post install script install location.
 postinst_filepath="/tmp/deb-ctrl-data/postinst"
 postinst_dirpath=$(dirname ${postinst_filepath})
-mkdir -r "${postinst_dirpath}"
+mkdir "${postinst_dirpath}"
 
 installed_package_count=$(wc -w <<< "${installed_packages}")
 log "Caching ${installed_package_count} installed packages..."

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -64,7 +64,7 @@ log_empty_line
 installed_package_count=$(wc -w <<< "${installed_packages}")
 log "Caching ${installed_package_count} installed packages..."
 for installed_package in ${installed_packages}; do
-  cache_filepath="${cache_dir}/${installed_package}.tar.gz"
+  cache_filepath="${cache_dir}/${installed_package}.tar"
 
   # Sanity test in case APT enumerates duplicates.
   if test ! -f "${cache_filepath}"; then
@@ -75,7 +75,7 @@ for installed_package in ${installed_packages}; do
       while IFS= read -r f; do     
         if test -f $f || test -L $f; then echo "${f:1}"; fi;  #${f:1} removes the leading slash that Tar disallows
       done |
-      sudo xargs tar -czf "${cache_filepath}" -C /      
+      sudo xargs tar -cf "${cache_filepath}" -C /      
     log "    done (compressed size $(du -h "${cache_filepath}" | cut -f1))."
   fi
 

--- a/lib.sh
+++ b/lib.sh
@@ -8,7 +8,7 @@
 #   Installation script extension (preinst, postinst).
 #   Parameter to pass to the installation script.
 # Returns:
-#   Filepath of the postinst file, otherwise an empty string.
+#   Filepath of the install script, otherwise an empty string.
 ###############################################################################
 function execute_install_script {
   local package_name=$(basename ${2} | awk -F\: '{print $1}')  

--- a/lib.sh
+++ b/lib.sh
@@ -52,5 +52,3 @@ function write_manifest {
   echo "${2:0:-1}" | tr ',' '\n' | sort > ${3}
   log "done"
 }
-
-get_installed_packages "/tmp/cache-apt-pkgs-action-cache/install.log"

--- a/lib.sh
+++ b/lib.sh
@@ -12,7 +12,8 @@
 ###############################################################################
 function execute_install_script {
   local package_name=$(basename ${2} | awk -F\: '{print $1}')  
-  local install_script_filepath=$(get_install_filepath "${1}" "${package_name}" "${3}")
+  local install_script_filepath=$(\
+    get_install_filepath "${1}" "${package_name}" "${3}")
   if test ! -z "${install_script_filepath}"; then
     log "- Executing ${install_script_filepath}..."
     # Don't abort on errors; dpkg-trigger will error normally since it is outside 
@@ -87,9 +88,10 @@ function get_package_name_from_cached_filepath {
 #   Filepath of the script file, otherwise an empty string.
 ###############################################################################
 function get_install_filepath {
-  local error_on_exit=$(shopt -op | grep errexit)  
   # Filename includes arch (e.g. amd64).
-  local filepath="$(ls -1 ${1}/var/lib/dpkg/info/${2}:*.${3} 2> /dev/null | head -1 || true)"
+  local filepath="$(\
+    ls -1 ${1}var/lib/dpkg/info/${2}*.${3} \
+    | grep -E ${2}'(:.*)?.'${3} | head -1)"
   test "${filepath}" && echo "${filepath}"
 }
 
@@ -125,7 +127,9 @@ function log_empty_line { echo ""; }
 function normalize_package_list {
   local stripped=$(echo "${1}" | sed 's/,//g')
   # Remove extraneous spaces at the middle, beginning, and end.
-  local trimmed="$(echo "${stripped}" | sed 's/\s\+/ /g; s/^\s\+//g; s/\s\+$//g')"
+  local trimmed="$(\
+    echo "${stripped}" \
+    | sed 's/\s\+/ /g; s/^\s\+//g; s/\s\+$//g')"
   local sorted="$(echo ${trimmed} | tr ' ' '\n' | sort | tr '\n' ' ')"
   echo "${sorted}"  
 }

--- a/lib.sh
+++ b/lib.sh
@@ -16,8 +16,8 @@ function execute_install_script {
     get_install_filepath "${1}" "${package_name}" "${3}")
   if test ! -z "${install_script_filepath}"; then
     log "- Executing ${install_script_filepath}..."
-    # Don't abort on errors; dpkg-trigger will error normally since it is outside 
-    # its run environment.
+    # Don't abort on errors; dpkg-trigger will error normally since it is
+    # outside its run environment.
     sudo sh -x ${install_script_filepath} ${4} || true
     log "  done"
   fi
@@ -90,8 +90,8 @@ function get_package_name_from_cached_filepath {
 function get_install_filepath {
   # Filename includes arch (e.g. amd64).
   local filepath="$(\
-    ls -1 ${1}var/lib/dpkg/info/${2}*.${3} \
-    | grep -E ${2}'(:.*)?.'${3} | head -1)"
+    ls -1 ${1}var/lib/dpkg/info/${2}*.${3} 2> /dev/null \
+    | grep -E ${2}'(:.*)?.'${3} | head -1 || true)"
   test "${filepath}" && echo "${filepath}"
 }
 

--- a/lib.sh
+++ b/lib.sh
@@ -46,9 +46,13 @@ function log_err { >&2 echo "$(date +%H:%M:%S)" "${@}"; }
 function log_empty_line { echo ""; }
 
 # Writes the manifest to a specified file.
-function write_manifest {
-  log "Writing ${1} packages manifest to ${3}..."  
-  # 0:-1 to remove trailing comma, delimit by newline and sort.
-  echo "${2:0:-1}" | tr ',' '\n' | sort > ${3}
-  log "done"
+function write_manifest {  
+  if [ ${#2} -eq 0 ]; then 
+    log "Skipped ${1} manifest write. No packages to install."
+  else
+    log "Writing ${1} packages manifest to ${3}..."
+    # 0:-1 to remove trailing comma, delimit by newline and sort.
+    echo "${2:0:-1}" | tr ',' '\n' | sort > ${3}
+    log "done"
+  fi
 }

--- a/lib.sh
+++ b/lib.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 # Sort these packages by name and split on commas.
+#######################################
+# Sorts given packages by name and split on commas.
+# Arguments:
+#   The comma delimited list of packages.
+# Returns:
+#   Sorted list of space delimited packages.
+#######################################
 function normalize_package_list {
   local stripped=$(echo "${1}" | sed 's/,//g')
   # Remove extraneous spaces at the middle, beginning, and end.
@@ -9,8 +16,14 @@ function normalize_package_list {
   echo "${sorted}"  
 }
 
-# Gets a list of installed packages as space delimited pairs with each pair colon delimited.
+#######################################
+# Gets a list of installed packages from a Debian package installation log.
+# Arguments:
+#   The filepath of the Debian install log.
+# Returns:
+#   The list of space delimited pairs with each pair colon delimited.
 #   <name>:<version> <name:version>...
+#######################################
 function get_installed_packages {   
   install_log_filepath="${1}"
   local regex="^Unpacking ([^ :]+)([^ ]+)? (\[[^ ]+\]\s)?\(([^ )]+)"  
@@ -30,7 +43,13 @@ function get_installed_packages {
   fi
 }
 
-# Split fully qualified package into name and version.
+#######################################
+# Splits a fully qualified package into name and version.
+# Arguments:
+#   The colon delimited package pair or just the package name.
+# Returns:
+#   The package name and version pair.
+#######################################
 function get_package_name_ver {
   IFS=\: read name ver <<< "${1}"
   # If version not found in the fully qualified package value.
@@ -40,12 +59,36 @@ function get_package_name_ver {
   echo "${name}" "${ver}"
 }
 
+#######################################
+# Gets the Debian postinst file location.
+# Arguments:
+#   Name of the unqualified package to search for.
+# Returns:
+#   Filepath of the postinst file, otherwise an empty string.
+#######################################
+function get_postinst_filepath {
+  filepath="/var/lib/dpkg/info/${1}"
+  if test -f "${filepath}"; then
+    echo "${filepath}"
+  else
+    echo ""
+  fi
+}
+
 function log { echo "$(date +%H:%M:%S)" "${@}"; }
 function log_err { >&2 echo "$(date +%H:%M:%S)" "${@}"; }
 
 function log_empty_line { echo ""; }
 
+#######################################
 # Writes the manifest to a specified file.
+# Arguments:
+#   Type of manifest being written.
+#   List of packages being written to the file.
+#   File path of the manifest being written.
+# Returns:
+#   Log lines from write.
+#######################################
 function write_manifest {  
   if [ ${#2} -eq 0 ]; then 
     log "Skipped ${1} manifest write. No packages to install."

--- a/lib.sh
+++ b/lib.sh
@@ -135,6 +135,23 @@ function normalize_package_list {
 }
 
 ###############################################################################
+# Validates an argument to be of a boolean value.
+# Arguments:
+#   Argument to validate.
+#   Variable name of the argument.
+#   Exit code if validation fails.
+# Returns:
+#   Sorted list of space delimited packages.
+###############################################################################
+function validate_bool {
+  if test "${1}" != "true" -a "${1}" != "false"; then
+    log "aborted"
+    log "${2} value '${1}' must be either true or false (case sensitive)."
+    exit ${3}
+  fi
+}
+
+###############################################################################
 # Writes the manifest to a specified file.
 # Arguments:
 #   Type of manifest being written.

--- a/post_cache_action.sh
+++ b/post_cache_action.sh
@@ -21,15 +21,17 @@ cache_hit="${3}"
 # Cache and execute post install scripts on restore.
 execute_install_scripts="${4}"
 
-# List of the packages to use.
-packages="${@:5}"
+# Debug mode for diagnosing issues.
+debug="${5}"
+test ${debug} == "true" && set -x
 
-script_dir="$(dirname -- "$(realpath -- "${0}")")"
+# List of the packages to use.
+packages="${@:6}"
 
 if [ "$cache_hit" == true ]; then
-  ${script_dir}/restore_pkgs.sh "${cache_dir}" "${cache_restore_root}" "${execute_install_scripts}"
+  ${script_dir}/restore_pkgs.sh "${cache_dir}" "${cache_restore_root}" "${execute_install_scripts}" "${debug}"
 else
-  ${script_dir}/install_and_cache_pkgs.sh "${cache_dir}" ${packages}
+  ${script_dir}/install_and_cache_pkgs.sh "${cache_dir}" "${debug}" ${packages}
 fi
 
 log_empty_line

--- a/post_cache_action.sh
+++ b/post_cache_action.sh
@@ -26,9 +26,9 @@ packages="${@:5}"
 script_dir="$(dirname -- "$(realpath -- "${0}")")"
 
 if [ "$cache_hit" == true ]; then
-  ${script_dir}/restore_pkgs.sh ~/cache-apt-pkgs "${cache_restore_root}" "${execute_postinst}"
+  ${script_dir}/restore_pkgs.sh "${cache_dir}" "${cache_restore_root}" "${execute_postinst}"
 else
-  ${script_dir}/install_and_cache_pkgs.sh ~/cache-apt-pkgs "${execute_postinst}" ${packages}
+  ${script_dir}/install_and_cache_pkgs.sh "${cache_dir}" "${execute_postinst}" ${packages}
 fi
 
 log_empty_line

--- a/post_cache_action.sh
+++ b/post_cache_action.sh
@@ -12,13 +12,14 @@ cache_dir="${1}"
 
 # Root directory to untar the cached packages to.
 # Typically filesystem root '/' but can be changed for testing.
+# WARNING: If non-root, this can cause errors during install script execution.
 cache_restore_root="${2}"
 
 # Indicates that the cache was found.
 cache_hit="${3}"
 
 # Cache and execute post install scripts on restore.
-execute_postinst="${4}"
+execute_install_scripts="${4}"
 
 # List of the packages to use.
 packages="${@:5}"
@@ -26,9 +27,9 @@ packages="${@:5}"
 script_dir="$(dirname -- "$(realpath -- "${0}")")"
 
 if [ "$cache_hit" == true ]; then
-  ${script_dir}/restore_pkgs.sh "${cache_dir}" "${cache_restore_root}" "${execute_postinst}"
+  ${script_dir}/restore_pkgs.sh "${cache_dir}" "${cache_restore_root}" "${execute_install_scripts}"
 else
-  ${script_dir}/install_and_cache_pkgs.sh "${cache_dir}" "${execute_postinst}" ${packages}
+  ${script_dir}/install_and_cache_pkgs.sh "${cache_dir}" ${packages}
 fi
 
 log_empty_line

--- a/post_cache_action.sh
+++ b/post_cache_action.sh
@@ -17,15 +17,18 @@ cache_restore_root="${2}"
 # Indicates that the cache was found.
 cache_hit="${3}"
 
+# Cache and execute post install scripts on restore.
+execute_postinst="${4}"
+
 # List of the packages to use.
-packages="${@:4}"
+packages="${@:5}"
 
 script_dir="$(dirname -- "$(realpath -- "${0}")")"
 
 if [ "$cache_hit" == true ]; then
-  ${script_dir}/restore_pkgs.sh ~/cache-apt-pkgs "${cache_restore_root}"
+  ${script_dir}/restore_pkgs.sh ~/cache-apt-pkgs "${cache_restore_root}" "${execute_postinst}"
 else
-  ${script_dir}/install_and_cache_pkgs.sh ~/cache-apt-pkgs ${packages}
+  ${script_dir}/install_and_cache_pkgs.sh ~/cache-apt-pkgs "${execute_postinst}" ${packages}
 fi
 
 log_empty_line

--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -11,7 +11,7 @@ cache_dir="${1}"
 version="${2}"
 
 # Execute post-installation script.
-execute_postinst="${3}"
+execute_install_scripts="${3}"
 
 # List of the packages to use.
 input_packages="${@:4}"
@@ -36,9 +36,9 @@ if test -z "${packages}"; then
   exit 2
 fi
 
-if test "${execute_postinst}" != "true" -o "${execute_postinst}" != "false"; then
+if test "${execute_install_scripts}" != "true" -o "${execute_install_scripts}" != "false"; then
   log "aborted"
-  log "execute_postinst value '${execute_postinst}' must be either true or false (case sensitive)."
+  log "execute_install_scripts value '${execute_install_scripts}' must be either true or false (case sensitive)."
   exit 3
 fi
 

--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -10,8 +10,11 @@ cache_dir="${1}"
 # Version of the cache to create or load.
 version="${2}"
 
+# Execute post-installation script.
+execute_postinst="${3}"
+
 # List of the packages to use.
-input_packages="${@:3}"
+input_packages="${@:4}"
 
 # Trim commas, excess spaces, and sort.
 packages="$(normalize_package_list "${input_packages}")"
@@ -33,6 +36,12 @@ if test -z "${packages}"; then
   exit 2
 fi
 
+if test "${execute_postinst}" != "true" -o "${execute_postinst}" != "false"; then
+  log "aborted"
+  log "execute_postinst value '${execute_postinst}' must be either true or false (case sensitive)."
+  exit 3
+fi
+
 log "done"
 
 log_empty_line
@@ -50,7 +59,7 @@ for package in ${packages}; do
   if test ! "$(apt-cache show "${package}")"; then
     echo "aborted"
     log "Package '${package}' not found." >&2
-    exit 3
+    exit 4
   fi
   read package_name package_ver < <(get_package_name_ver "${package}")
   versioned_packages=""${versioned_packages}" "${package_name}"="${package_ver}""

--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -36,7 +36,7 @@ if test -z "${packages}"; then
   exit 2
 fi
 
-if test "${execute_install_scripts}" != "true" -o "${execute_install_scripts}" != "false"; then
+if test "${execute_install_scripts}" != "true" -a "${execute_install_scripts}" != "false"; then
   log "aborted"
   log "execute_install_scripts value '${execute_install_scripts}' must be either true or false (case sensitive)."
   exit 3

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Fail on any error.
 set -e
@@ -46,7 +46,7 @@ for cached_pkg_filepath in ${cached_pkg_filepaths}; do
   log "  done"
 
   # Execute install scripts if available.    
-  if test "${execute_install_scripts}" == "true"; then
+  if test ${execute_install_scripts} == "true"; then
     # May have to add more handling for extracting pre-install script before extracting all files.
     # Keeping it simple for now.
     execute_install_script "${cache_restore_root}" "${cached_pkg_filepath}" preinst install

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -39,16 +39,20 @@ cached_pkg_filecount=$(echo ${cached_pkg_filepaths} | wc -w)
 
 log "Restoring ${cached_pkg_filecount} packages from cache..."
 for cached_pkg_filepath in ${cached_pkg_filepaths}; do
+
   log "- $(basename "${cached_pkg_filepath}") restoring..."
-
   sudo tar -xf "${cached_pkg_filepath}" -C "${cache_restore_root}" > /dev/null
-
-  # Execute post install script if available.
-  postinst_filepath=$(get_postinst_filepath "${package_name}")
-  if test "${execute_postinst}" == "true" && test ! -z "${postinst_filepath}"; then
-    sh -x ${postint_filepath}    
-  fi
-
   log "  done"
+
+  # Execute post install script if available.    
+  if test "${execute_postinst}" == "true"; then
+    package_name=$(get_package_name_from_cached_filepath ${package_name})
+    postinst_filepath=$(get_postinst_filepath "${cache_restore_root}" "${package_name}")
+    if test ! -z "${postinst_filepath}"; then
+      log "- Executing ${postinst_filepath}..."
+      sudo sh -x ${postinst_filepath}
+      log "  done"
+    fi
+  fi  
 done
 log "done"

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -3,6 +3,11 @@
 # Fail on any error.
 set -e
 
+# Debug mode for diagnosing issues.
+# Setup first before other operations.
+debug="${4}"
+test ${debug} == "true" && set -x
+
 # Include library.
 script_dir="$(dirname -- "$(realpath -- "${0}")")"
 source "${script_dir}/lib.sh"

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Fail on any error.
 set -e

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -37,21 +37,16 @@ log_empty_line
 cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar | sort)
 cached_pkg_filecount=$(echo ${cached_pkg_filepaths} | wc -w)
 
-# Post install script restore location.
-postint_filepath="/tmp/deb-ctrl-data/postinst"
-
 log "Restoring ${cached_pkg_filecount} packages from cache..."
 for cached_pkg_filepath in ${cached_pkg_filepaths}; do
   log "- $(basename "${cached_pkg_filepath}") restoring..."
 
   sudo tar -xf "${cached_pkg_filepath}" -C "${cache_restore_root}" > /dev/null
 
-  if test "${execute_postinst}" == "true"; then
-    # Execute post install script if available.
-    if test -f "${postint_filepath}"; then
-      sh -x ${postint_filepath}
-      rm -fr ${postint_filepath}
-    fi
+  # Execute post install script if available.
+  postinst_filepath=$(get_postinst_filepath "${package_name}")
+  if test "${execute_postinst}" == "true" && test ! -z "${postinst_filepath}"; then
+    sh -x ${postint_filepath}    
   fi
 
   log "  done"

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -14,6 +14,9 @@ cache_dir="${1}"
 # Typically filesystem root '/' but can be changed for testing.
 cache_restore_root="${2}"
 
+# Cache and execute post install scripts on restore.
+execute_postinst="${3}"
+
 cache_filepaths="$(ls -1 "${cache_dir}" | sort)"
 log "Found $(echo ${cache_filepaths} | wc -w) files in the cache."
 for cache_filepath in ${cache_filepaths}; do
@@ -33,10 +36,24 @@ log_empty_line
 # Only search for archived results. Manifest and cache key also live here.
 cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar | sort)
 cached_pkg_filecount=$(echo ${cached_pkg_filepaths} | wc -w)
+
+# Post install script restore location.
+postint_filepath="/tmp/deb-ctrl-data/postinst"
+
 log "Restoring ${cached_pkg_filecount} packages from cache..."
 for cached_pkg_filepath in ${cached_pkg_filepaths}; do
   log "- $(basename "${cached_pkg_filepath}") restoring..."
+
   sudo tar -xf "${cached_pkg_filepath}" -C "${cache_restore_root}" > /dev/null
+
+  if test "${execute_postinst}" == "true"; then
+    # Execute post install script if available.
+    if test -f "${postint_filepath}"; then
+      sh -x ${postint_filepath}
+      rm -fr ${postint_filepath}
+    fi
+  fi
+
   log "  done"
 done
 log "done"

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -31,7 +31,7 @@ log "done"
 log_empty_line
 
 # Only search for archived results. Manifest and cache key also live here.
-cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar.gz | sort)
+cached_pkg_filepaths=$(ls -1 "${cache_dir}"/*.tar | sort)
 cached_pkg_filecount=$(echo ${cached_pkg_filepaths} | wc -w)
 log "Restoring ${cached_pkg_filecount} packages from cache..."
 for cached_pkg_filepath in ${cached_pkg_filepaths}; do


### PR DESCRIPTION
* Provide the ability to call Debian package manager installation scripts (i.e. `*.[preinst, postinst]`).
* Introduce a debug mode that runs the scripts in verbose mode and uploads the logs for retrieval.
* Updated README to reflect new features and provided more info on how to use the action versions.