### PR TITLE
docs: fix link to actions/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action allows caching of Advanced Package Tool (APT) package dependencies t
 
 ## Documentation
 
-This action is a composition of [actions/cache](https://github.com/actions/cache/README.md) and the `apt` utility. Some actions require additional APT based packages to be installed in order for other steps to be executed. Packages can be installed when ran but can consume much of the execution workflow time.
+This action is a composition of [actions/cache](https://github.com/actions/cache/) and the `apt` utility. Some actions require additional APT based packages to be installed in order for other steps to be executed. Packages can be installed when ran but can consume much of the execution workflow time.
 
 ## Usage
 


### PR DESCRIPTION
The current link returns a 404.