### PR TITLE
Fix if condition for upload-logs step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
 
     - id: upload-logs
-      if: ${{ inputs.debug }} == "true"
+      if: ${{ inputs.debug == 'true' }}
       uses: actions/upload-artifact@v3
       with:
         name: cache-apt-pkgs-logs%${{ inputs.packages }}%${{ inputs.version }}


### PR DESCRIPTION
Previously the if condition was always evaluating to a truthy string (e.g. 'false == "true"' or 'true == "true"') as the string comparison (`== 'true'`) was not inside the expression syntax (`${{ }}`) and thus being treated as a string rather than being evaluated.