### PR TITLE
More robust checking of age of apt cache

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -30,7 +30,7 @@ manifest_main=""
 log "Package list:"
 for package in ${normalized_packages}; do
   read package_name package_ver < <(get_package_name_ver "${package}")
-  manifest_main="${manifest_main}${package_name}:${package_ver},"  
+  manifest_main="${manifest_main}${package_name}:${package_ver},"
   log "- ${package_name}:${package_ver}"
 done
 write_manifest "main" "${manifest_main}" "${cache_dir}/manifest_main.log"
@@ -45,12 +45,11 @@ log "done"
 log_empty_line
 
 log "Updating APT package list..."
-last_update_delta_s=$(($(date +%s) - $(date +%s -r /var/cache/apt/pkgcache.bin)))
-if test $last_update_delta_s -gt 300; then
+if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5)" ]]; then
   sudo apt-fast update > /dev/null
   log "done"
 else
-  log "skipped (fresh by ${last_update_delta_s} seconds)"
+  log "skipped (fresh within at least 5 minutes)"
 fi
 
 log_empty_line


### PR DESCRIPTION
Somehow on my CI workflows, I was not seeing any `/var/cache/apt/pkgcache.bin`, which apparently is the case depending on which version of Debian/Ubuntu. This was resulting in job failures.

This PR is based on an answer I found in https://askubuntu.com/questions/410247/how-to-know-last-time-apt-get-update-was-executed and should make this check more robust.