### PR TITLE
Clean cache directory after use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
          PACKAGES: "${{ inputs.packages }}"
 
     - id: load-cache
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: ~/cache-apt-pkgs
         key: cache-apt-pkgs_${{ env.CACHE_KEY }}
@@ -82,6 +82,18 @@ runs:
          EXEC_INSTALL_SCRIPTS: "${{ inputs.execute_install_scripts }}"
          DEBUG: "${{ inputs.debug }}"
          PACKAGES: "${{ inputs.packages }}"
+
+    - id: save-cache
+      if: ${{ ! steps.load-cache.outputs.cache-hit }}
+      uses: actions/cache/save@v3
+      with:
+        path: ~/cache-apt-pkgs
+        key: ${{ steps.load-cache.outputs.cache-primary-key }}
+
+    - id: clean-cache
+      run: |
+        rm -rf ~/cache-apt-pkgs
+      shell: bash
 
     - id: upload-logs
       if: ${{ inputs.debug == 'true' }}


### PR DESCRIPTION
By splitting the restore and save steps of the cache action, we can run some steps after the post cache step which otherwise would be run at the end of the workflow.

This allows us to clean the cache directory after it has been saved. This fixes #94, allows us to save the cache even if the rest of the workflow fails and also has the minor benefit of reduced disk usage.

Differences for existing workflows:
* You can't rely on the `~/cache-apt-pkgs` directory being present (you shouldn't).
* There is no message from actions/checkout to indicate that the cache is not saved because a cache-hit has occurred.