### PR TITLE
Don't install apt-fast from source

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -37,13 +37,6 @@ write_manifest "main" "${manifest_main}" "${cache_dir}/manifest_main.log"
 
 log_empty_line
 
-log "Installing apt-fast for optimized installs..."
-# Install apt-fast for optimized installs.
-/bin/bash -c "$(curl -sL https://git.io/vokNn)"
-log "done"
-
-log_empty_line
-
 log "Updating APT package list..."
 if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5)" ]]; then
   sudo apt-fast update > /dev/null


### PR DESCRIPTION
There is no reason to install `apt-fast` from source as it is already included in all of the [Ubuntu runner images](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md).