### PR TITLE
Only install apt-fast from source if not present

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -37,12 +37,14 @@ write_manifest "main" "${manifest_main}" "${cache_dir}/manifest_main.log"
 
 log_empty_line
 
-log "Installing apt-fast for optimized installs..."
-# Install apt-fast for optimized installs.
-/bin/bash -c "$(curl -sL https://git.io/vokNn)"
-log "done"
+if ! apt-fast --version > /dev/null 2>&1; then
+  log "Installing apt-fast for optimized installs..."
+  # Install apt-fast for optimized installs.
+  /bin/bash -c "$(curl -sL https://git.io/vokNn)"
+  log "done"
 
-log_empty_line
+  log_empty_line
+fi
 
 log "Updating APT package list..."
 if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5)" ]]; then

--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -37,6 +37,13 @@ write_manifest "main" "${manifest_main}" "${cache_dir}/manifest_main.log"
 
 log_empty_line
 
+log "Installing apt-fast for optimized installs..."
+# Install apt-fast for optimized installs.
+/bin/bash -c "$(curl -sL https://git.io/vokNn)"
+log "done"
+
+log_empty_line
+
 log "Updating APT package list..."
 if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5)" ]]; then
   sudo apt-fast update > /dev/null


### PR DESCRIPTION
Install apt-fast only from source when it is not present as it is already included in all of the [Ubuntu runner images](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) but might not be on custom runners.

Fixes: https://github.com/awalsh128/cache-apt-pkgs-action/pull/96#issuecomment-1457811107

[Test with apt-fast present](https://github.com/pascallj/cache-apt-pkgs-action/actions/runs/4353061466/jobs/7606630095) and [test without apt-fast present](https://github.com/pascallj/cache-apt-pkgs-action/actions/runs/4353129373/jobs/7606793959).