### PR TITLE
Bump actions/cache/restore to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
          PACKAGES: "${{ inputs.packages }}"
 
     - id: load-cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ~/cache-apt-pkgs
         key: cache-apt-pkgs_${{ env.CACHE_KEY }}


### PR DESCRIPTION
I am getting the following warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache/restore@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

No breaking changes for v4 apparently, just the update to node 20: https://github.com/actions/cache/#v4