### PR TITLE
Use v4 of actions/cache/save too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
 
     - id: save-cache
       if: ${{ ! steps.load-cache.outputs.cache-hit }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ~/cache-apt-pkgs
         key: ${{ steps.load-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Needed to finish migration to node20 + probably wiser overall to use matching versions of the caching actions.