### PR TITLE
Use actions/upload-artifact v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - id: upload-logs
       if: ${{ inputs.debug == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cache-apt-pkgs-logs_${{ env.CACHE_KEY }}
         path: ~/cache-apt-pkgs/*.log


### PR DESCRIPTION
We need to use actions/upload-artifact V4 or the workflow will fail. See  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/