### PR TITLE
Upgrade to `actions/upload-artifact@v4`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
 
     - id: upload-logs
       if: ${{ inputs.debug == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cache-apt-pkgs-logs_${{ env.CACHE_KEY }}
         path: ~/cache-apt-pkgs/*.log


### PR DESCRIPTION
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/