### PR TITLE
fix: remove timestamps from loglines

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -135,8 +135,8 @@ function get_tar_relpath {
   fi
 }
 
-function log { echo "$(date +%T.%3N)" "${@}"; }
-function log_err { >&2 echo "$(date +%T.%3N)" "${@}"; }
+function log { echo "${@}"; }
+function log_err { >&2 echo "${@}"; }
 
 function log_empty_line { echo ""; }
 


### PR DESCRIPTION
I would like to propose to remove the timestamps from the logging in the output. In github actions, you have the options to display timestamps in the pipeline as can be seen in the screenshot. Therefor it should not be default behaviour to also show these with "built-in" logging.

![image](https://github.com/user-attachments/assets/36787d57-d3e5-4657-b8d0-e219782fcb18)
