### PR TITLE
Update actions/checkout versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Doxygen documentation and deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: dia doxygen doxygen-doc doxygen-gui doxygen-latex graphviz mscgen
@@ -82,7 +82,7 @@ jobs:
 install_doxygen_deps:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: dia doxygen doxygen-doc doxygen-gui doxygen-latex graphviz mscgen


### PR DESCRIPTION
[The latest 2.x release](https://github.com/actions/checkout/releases/tag/v2.7.0) was almost 2 years ago.