### PR TITLE
Automatically append the OS architecture to the cache key

### DIFF
--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -64,7 +64,18 @@ log "Creating cache key..."
 # and a global cache reset is required, or change in cache action requiring reload.
 force_update_inc="3"
 
+# Force a different cache key for different architectures (currently x86_64 and aarch64 are available on GitHub)
+cpu_arch="$(arch)"
+log "- CPU architecture is '${cpu_arch}'."
+
 value="${packages} @ ${version} ${force_update_inc}"
+
+# Don't invalidate existing caches for the standard Ubuntu runners
+if [ "${cpu_arch}" != "x86_64" ]; then
+  value="${value} ${cpu_arch}"
+  log "- Architecture '${cpu_arch}' added to value."
+fi
+
 log "- Value to hash is '${value}'."
 
 key="$(echo "${value}" | md5sum | cut -f1 -d' ')"


### PR DESCRIPTION
We had a user report as part of our Ubuntu arm64 rollout that tracked back to the apt package cache accidentally being shared between the x64 runners and arm64 runners. This resulted in some odd errors.

https://github.com/community/maintainers/discussions/480#discussioncomment-12206804

This change will add the CPU architecture to the key to be hashed. 

I am not adding it if it is current "normal" case of x86_64 for ubuntu-latest, ubuntu-24.04, and ubuntu-22.04 in an effort to not needlessly invalidate caches.

Logs from `ubuntu-latest`
```
Normalizing package list...
done
Validating action arguments (version='', packages='libfuse2=2.9.9-5ubuntu3 libqcustomplot-dev=2.0.1+dfsg1-5 libqscintilla2-qt5-dev=2.11.6+dfsg-4 libqt5svg5=5.15.3-1 ninja-build=1.10.1-1 qttools5-dev=5.15.3-1')...
done
Creating cache key...
- CPU architecture is 'x86_64'.
- Value to hash is 'libfuse2=2.9.9-5ubuntu3 libqcustomplot-dev=2.0.1+dfsg1-5 libqscintilla2-qt5-dev=2.11.6+dfsg-4 libqt5svg5=5.15.3-1 ninja-build=1.10.1-1 qttools5-dev=5.15.3-1 @  3'.
- Value hashed as '7249e230c6406f49de3a7775bbe7ded2'.
done
Hash value written to /home/runner/cache-apt-pkgs/cache_key.md5
Run actions/cache/restore@v4
  
Cache not found for input keys: cache-apt-pkgs_7249e230c6406f49de3a7775bbe7ded2
Run ${GITHUB_ACTION_PATH}/post_cache_action.sh \
  
Updating APT package list...
done
```

Logs from `ubuntu-24.04-arm`
```
Normalizing package list...
done
Validating action arguments (version='', packages='libfuse2=2.9.9-5ubuntu3 libqcustomplot-dev=2.0.1+dfsg1-5 libqscintilla2-qt5-dev=2.11.6+dfsg-4 libqt5svg5=5.15.3-1 ninja-build=1.10.1-1 qttools5-dev=5.15.3-1')...
done
Creating cache key...
- CPU architecture is 'aarch64'.
- Architecture 'aarch64' added to value.
- Value to hash is 'libfuse2=2.9.9-5ubuntu3 libqcustomplot-dev=2.0.1+dfsg1-5 libqscintilla2-qt5-dev=2.11.6+dfsg-4 libqt5svg5=5.15.3-1 ninja-build=1.10.1-1 qttools5-dev=5.15.3-1 @  3 aarch64'.
- Value hashed as '62b41aa5465640843bc389516657d8f0'.
done
Hash value written to /home/runner/cache-apt-pkgs/cache_key.md5
Run actions/cache/restore@v4
Cache not found for input keys: cache-apt-pkgs_62b41aa5465640843bc389516657d8f0
Run ${GITHUB_ACTION_PATH}/post_cache_action.sh \
Updating APT package list...
done
```

