### PR TITLE
Add if-empty-packages optional input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ There are three kinds of version labels you can use.
 - `packages` - Space delimited list of packages to install.
 - `version` - Version of cache to load. Each version will have its own cache. Note, all characters except spaces are allowed.
 - `execute_install_scripts` - Execute Debian package pre and post install script upon restore. See [Caveats / Non-file Dependencies](#non-file-dependencies) for more information.
+- `empty_packages_behavior` - Desired behavior when the given `packages` is empty. `'error'` (default), `'warn'` or `'ignore'`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,16 @@ inputs:
     description: 'Execute Debian package pre and post install script upon restore. See README.md caveats for more information.'
     required: false
     default: 'false'
+  empty_packages_behavior:
+    description: >
+      Desired behavior when the provided package list is empty.
+
+      Available Options:
+        error: Fail the action with an error message
+        warn: Output a warning without failing the action
+        ignore: Proceed silently without warnings or errors
+    required: false
+    default: 'error'
   refresh:
     description: 'OBSOLETE: Refresh is not used by the action, use version instead.'
     deprecationMessage: 'Refresh is not used by the action, use version instead.'
@@ -50,21 +60,28 @@ runs:
           "$EXEC_INSTALL_SCRIPTS" \
           "$DEBUG" \
           "$PACKAGES"
-        echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
+        if [ -f ~/cache-apt-pkgs/cache_key.md5 ]; then
+          echo "CACHE_KEY=$(cat ~/cache-apt-pkgs/cache_key.md5)" >> $GITHUB_ENV
+        else
+          echo "CACHE_KEY=" >> $GITHUB_ENV
+        fi
       shell: bash
       env:
          VERSION: "${{ inputs.version }}"
          EXEC_INSTALL_SCRIPTS: "${{ inputs.execute_install_scripts }}"
+         EMPTY_PACKAGES_BEHAVIOR: "${{ inputs.empty_packages_behavior }}"
          DEBUG: "${{ inputs.debug }}"
          PACKAGES: "${{ inputs.packages }}"
 
     - id: load-cache
+      if: ${{ env.CACHE_KEY }}
       uses: actions/cache/restore@v4
       with:
         path: ~/cache-apt-pkgs
         key: cache-apt-pkgs_${{ env.CACHE_KEY }}
 
     - id: post-cache
+      if: ${{ env.CACHE_KEY }}
       run: |
         ${GITHUB_ACTION_PATH}/post_cache_action.sh \
           ~/cache-apt-pkgs \
@@ -84,14 +101,14 @@ runs:
          PACKAGES: "${{ inputs.packages }}"
 
     - id: upload-logs
-      if: ${{ inputs.debug == 'true' }}
+      if: ${{ env.CACHE_KEY && inputs.debug == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: cache-apt-pkgs-logs_${{ env.CACHE_KEY }}
         path: ~/cache-apt-pkgs/*.log
 
     - id: save-cache
-      if: ${{ ! steps.load-cache.outputs.cache-hit }}
+      if: ${{ env.CACHE_KEY && ! steps.load-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ~/cache-apt-pkgs

--- a/pre_cache_action.sh
+++ b/pre_cache_action.sh
@@ -44,9 +44,20 @@ fi
 
 # Is length of string zero?
 if test -z "${packages}"; then
-  log "aborted"
-  log "Packages argument cannot be empty." >&2
-  exit 3
+  case "$EMPTY_PACKAGES_BEHAVIOR" in
+    ignore)
+      exit 0
+      ;;
+    warn)
+      echo "::warning::Packages argument is empty."
+      exit 0
+      ;;
+    *)
+      log "aborted"
+      log "Packages argument is empty." >&2
+      exit 3
+      ;;
+  esac
 fi
 
 validate_bool "${execute_install_scripts}" execute_install_scripts 4


### PR DESCRIPTION
This is an implementation for #149.

If the `if-empty-packages` option (default: `error`) is set to `warn` or `ignore`, the action proceeds by setting `CACHE_KEY` to empty. Then, the subsequent steps are skipped.

Renaming `if-empty-packages` to `if-packages-empty` or `if_empty_packages` etc. is fine with me if you prefer.