### PR TITLE
install_and_cache_pkgs.sh: Fix two issues saving preinst and postinst scripts.

### DIFF
--- a/install_and_cache_pkgs.sh
+++ b/install_and_cache_pkgs.sh
@@ -104,8 +104,8 @@ for installed_package in ${installed_packages}; do
     # Pipe all package files (no folders), including symlinks, their targets, and installation control data to Tar.
     tar -cf "${cache_filepath}" -C / --verbatim-files-from --files-from <(
       { dpkg -L "${package_name}" &&
-        get_install_script_filepath "" "${package_name}" "preinst" &&
-        get_install_script_filepath "" "${package_name}" "postinst" ; } |
+        { get_install_script_filepath "/" "${package_name}" "preinst" ;
+        get_install_script_filepath "/" "${package_name}" "postinst" ; } ; } |
       while IFS= read -r f; do
         if test -f "${f}" -o -L "${f}"; then
           get_tar_relpath "${f}"


### PR DESCRIPTION
1.  The logic for listing the files to be cached was using `&&`s between
the listing of the package files, the preinst script and postinst script.
Therefore if there wasn't a preinst script, a postinst script wasn't
checked for.

2. get_install_script_filepath was being passed an empty root file path
so it would never find any files.

Resolves: #194
