### PR TITLE
Preserve apt package install order on restore.

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -148,7 +148,9 @@ function get_tar_relpath {
 function update_apt_lists_if_stale {
   # Only check for stale package lists when running in nektos/act
   # GitHub Actions runners have fresh package lists, so skip this overhead
-  if [ "${ACT}" = "true" ]; then
+  # ACT comes from the environment
+  # shellcheck disable=SC2154
+  if [[ "${ACT}" = "true" ]]; then
     if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5 2>/dev/null)" ]]; then
       log "APT package lists are stale, updating..."
       if command -v apt-fast > /dev/null 2>&1; then
@@ -200,7 +202,7 @@ function write_manifest {
   else
     log "Writing ${1} packages manifest to ${3}..."
     # 0:-1 to remove trailing comma, delimit by newline and sort.
-    echo "${2:0:-1}" | tr ',' '\n' | sort > ${3}
+    echo "${2:0:-1}" | tr ',' '\n' > "${3}"
     log "done"
   fi
 }

--- a/restore_pkgs.sh
+++ b/restore_pkgs.sh
@@ -40,13 +40,15 @@ log "done"
 log_empty_line
 
 # Only search for archived results. Manifest and cache key also live here.
-cached_filepaths=$(ls -1 "${cache_dir}"/*.tar 2>/dev/null | sort)
-cached_filecount=$(echo ${cached_filepaths} | wc -w)
+manifest_all="${cache_dir}/manifest_all.log"
+mapfile -t packages <"${manifest_all}"
 
+cached_filecount="${#packages[@]}"
 log "Restoring ${cached_filecount} packages from cache..."
-for cached_filepath in ${cached_filepaths}; do
 
-  log "- $(basename "${cached_filepath}") restoring..."
+for package in "${packages[@]}"; do
+  cached_filepath="${cache_dir}/${package}.tar"
+  log "- ${package} restoring..."
   sudo tar -xf "${cached_filepath}" -C "${cache_restore_root}" > /dev/null
   log "  done"
 


### PR DESCRIPTION
* The manifest_all.log file is now kept in the order apt installed the packages.
* restore_pkgs.sh now restores packages in the order they are in the
manifest_all.log file instead of the order of the tarballs in the filesystem.

Resolves: #196
