### PR TITLE
fix: upgrade actions/cache v4→v5 and upload-artifact v4→v7 (Node 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
 
     - id: load-cache
       if: ${{ env.CACHE_KEY }}
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@v5
       with:
         path: ~/cache-apt-pkgs
         key: cache-apt-pkgs_${{ env.CACHE_KEY }}
@@ -110,14 +110,14 @@ runs:
 
     - id: upload-logs
       if: ${{ env.CACHE_KEY && inputs.debug == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@v7
       with:
         name: cache-apt-pkgs-logs_${{ env.CACHE_KEY }}
         path: ~/cache-apt-pkgs/*.log
 
     - id: save-cache
       if: ${{ env.CACHE_KEY && ! steps.load-cache.outputs.cache-hit }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/save@v5
       with:
         path: ~/cache-apt-pkgs
         key: ${{ steps.load-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions dependencies from Node 20 to Node 24 using version tags.

## Why
Node.js 20 actions are deprecated. GitHub will force Node.js 24 starting June 2, 2026 and remove Node.js 20 on September 16, 2026.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes
- `actions/cache/restore` v4 → **v5**
- `actions/cache/save` v4 → **v5**
- `actions/upload-artifact` v4.6.2 → **v7**

Uses version tags (`@v5`, `@v7`) instead of SHA pins for readability. For SHA-pinned versions of the same upgrade, see #193.