### PR TITLE
Add workflow to move latest tag on tag push

### DIFF
--- a/.github/workflows/latest_tag.yml
+++ b/.github/workflows/latest_tag.yml
@@ -1,0 +1,16 @@
+name: Update latest tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update_latest_tag:
+    runs-on: ubuntu-latest
+    name: Move latest tag
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: EndBug/latest-tag@latest


### PR DESCRIPTION
**Edit** This should fix https://github.com/awalsh128/cache-apt-pkgs-action/issues/199

**Edit 2** Not wished by the maintainer https://github.com/awalsh128/cache-apt-pkgs-action/issues/199#issuecomment-4700114939

Current `latest` does not point to the latest release.

Instead of a manual update - this PR adds an automatic update using the GitHub action https://github.com/EndBug/latest-tag.

<img width="620" height="685" alt="grafik" src="https://github.com/user-attachments/assets/b1fc0544-e26a-4ea5-a11f-b0b06c85d1be" />
