### PR TITLE
fix: refresh APT lists on all runners when stale, not just nektos/act

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -146,20 +146,23 @@ function get_tar_relpath {
 #   None
 ###############################################################################
 function update_apt_lists_if_stale {
-  # Only check for stale package lists when running in nektos/act
-  # GitHub Actions runners have fresh package lists, so skip this overhead
-  if [ "${ACT}" = "true" ]; then
-    if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5 2>/dev/null)" ]]; then
-      log "APT package lists are stale, updating..."
-      if command -v apt-fast > /dev/null 2>&1; then
-        sudo apt-fast update > /dev/null 2>&1 || sudo apt update > /dev/null 2>&1 || true
-      else
-        sudo apt update > /dev/null 2>&1 || true
-      fi
-      log "APT package lists updated"
+  # Package lists must be current before resolving/installing packages.
+  # GitHub-hosted runners ship fresh lists, but custom images (e.g. runs-on
+  # AMIs) and nektos/act may have stale or empty lists. With stale lists,
+  # `apt-cache show` misreports real packages (e.g. ghostscript) as purely
+  # virtual, which sends normalization down the "Reverse Provides:" path and
+  # yields a bogus package name. Refresh whenever the lists look stale, on any
+  # runner (not just nektos/act).
+  if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mmin -5 2>/dev/null)" ]]; then
+    log "APT package lists are stale, updating..."
+    if command -v apt-fast > /dev/null 2>&1; then
+      sudo apt-fast update > /dev/null 2>&1 || sudo apt update > /dev/null 2>&1 || true
     else
-      log "APT package lists are fresh (within 5 minutes), skipping update"
+      sudo apt update > /dev/null 2>&1 || true
     fi
+    log "APT package lists updated"
+  else
+    log "APT package lists are fresh (within 5 minutes), skipping update"
   fi
 }
 


### PR DESCRIPTION
## What
Removes the `ACT`-only gate around the stale-list refresh in `update_apt_lists_if_stale` (`lib.sh`) so it runs on **any** runner whose APT lists are stale — not only under nektos/act.

Closes #218.

## Why (root cause)
On runner images whose `/var/lib/apt/lists` is baked at image-build time and not refreshed on boot (e.g. [runs-on](https://runs-on.com) `ubuntu24-full-x64` AMIs), `apt-cache show <pkg>` runs against stale lists and can misreport a **real, installable** package such as `ghostscript` as *purely virtual*. That pushes `apt_query` normalization into the `Reverse Provides:` branch of `getNonVirtualPackage` (`src/internal/common/apt.go`), which returns the section-header line itself, so the normalized package becomes the bogus token `Reverse=Provides:`. The action then runs `apt-get install Reverse` -> `E: Unable to locate package Reverse`, installs nothing, and — since the step exits 0 — downstream jobs silently run without the package.

The prior code only refreshed under `ACT`, on the assumption *"GitHub Actions runners have fresh package lists."* That's true for GitHub-hosted runners but **not** for custom/self-hosted images, which therefore hit the stale-list path.

This is distinct from #210 (the `${*:6}` empty-`packages` regression) — here `packages` isn't empty, it's actively mis-resolved.

## Change
`lib.sh` -> `update_apt_lists_if_stale`: drop the `if [ "${ACT}" = "true" ]` wrapper; keep the existing 5-minute mtime staleness check. Net effect: refresh when lists are stale, on any runner.

## Validation (real CI on a runs-on `ubuntu24-full-x64` / Ubuntu 24.04 AMI)
**Before** (`v1.6.3`, `packages: ghostscript`):
```
Validating action arguments (version='...', packages='Reverse=Provides:')...
Clean installing 1 packages...
E: Unable to locate package Reverse
Caching 0 installed packages...
```
**After** (this branch):
```
APT package lists are stale, updating...
APT package lists updated
Validating action arguments (version='...', packages='ghostscript=10.02.1~dfsg1-0ubuntu7.8')...
Clean installing 1 packages...
Caching 15 installed packages...
```
Ghostscript installs, and the downstream `gs`-dependent test suite runs and passes.

## Trade-off / open question
The original `ACT` gate appears intended to avoid the `apt update` cost on GitHub-hosted runners. Because the staleness check keys off the lists-directory mtime (image-build time), this will now also trigger a one-time `apt update` on GitHub-hosted runners (a few seconds per job). If you'd rather keep the fast path there, alternatives: (a) refresh only when normalization fails to resolve a package, then retry; or (b) keep this and document the minor overhead. Happy to adjust to your preference.

## Possible follow-up (out of scope here)
Even with fresh lists, `getNonVirtualPackage` capturing the `Reverse Provides:` header is a latent parser bug for genuinely-virtual packages. Hardening it (skip the header / stop at any `...:` section line) would be a good defensive follow-up.
